### PR TITLE
fixed: enhanced readability and error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea/


### PR DESCRIPTION
In case the image is corrupted, there could have been some complications which are now handled by clamping the pixel values between (0, 255) and further throwing a panic in case the ```from_range``` wasn't passed properly. (the 2nd case is highly unlikely but its still good to take precautions)